### PR TITLE
Separate the decorator into it’s own file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ Quick start
 
 #. Mark your class-based view with the decorator provided by thumber::
 
-    from thumber import thumber_feedback
+    from thumber.decorators import thumber_feedback
 
     @thumber_feedback
     class MyView(...):

--- a/integration_tests/tests.py
+++ b/integration_tests/tests.py
@@ -1,8 +1,10 @@
 from django.test import TestCase
 from django.core.urlresolvers import reverse
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 
 from thumber.models import ContentFeedback
+from thumber.decorators import thumber_feedback
 
 
 class ThumberTests(TestCase):
@@ -133,3 +135,21 @@ class ThumberTests(TestCase):
         self.assertContains(response, 'Send feedback!')
         self.assertNotContains(response, 'test after form')
         self.assertContains(response, '<input type="reset" value="reset" />')
+
+    def test_cannot_decorate_view_function(self):
+        """Attempt tp decorate a view function, check that ImproperlyConfigured gets raised,
+        as it can only be used to decorate django class-based views
+        """
+        with self.assertRaises(ImproperlyConfigured):
+            @thumber_feedback
+            def view_function(request):
+                return None
+
+    def test_cannot_decorate_non_class_views(self):
+        """Attempt tp decorate a class that does not inherit django.views.generic.View, 
+        ImproperlyConfigured should get raised, as it can only be used to decorate django class-based views
+        """
+        with self.assertRaises(ImproperlyConfigured):
+            @thumber_feedback
+            class NonClassView():
+                pass

--- a/integration_tests/views.py
+++ b/integration_tests/views.py
@@ -1,7 +1,7 @@
 from django.views.generic import FormView, TemplateView
 from django.core.urlresolvers import reverse_lazy
 
-from thumber import thumber_feedback
+from thumber.decorators import thumber_feedback
 
 from .forms import ExampleForm
 

--- a/thumber/__init__.py
+++ b/thumber/__init__.py
@@ -2,5 +2,5 @@ default_app_config = 'thumber.apps.ThumberConfig'
 
 
 def _expose_items():
-    from .views import thumber_feedback
+    from .decorators import thumber_feedback
     globals()['thumber_feedback'] = thumber_feedback

--- a/thumber/decorators.py
+++ b/thumber/decorators.py
@@ -1,0 +1,15 @@
+import types
+
+from django.core.exceptions import ImproperlyConfigured
+from django.views.generic import View
+
+from .views import ContentFeedbackView
+
+
+def thumber_feedback(view):
+    # Cannot wrap view functions or classes that don't inherit from class-based View
+    if type(view) is types.FunctionType or not issubclass(view, View):
+        raise ImproperlyConfigured('Only class-based views can be decorated with `thumber_feedback')
+
+    # Make a new class that inherits from the ContentFeedbackView, and the wrapped view class
+    return type('ThumberFeedbackView', (ContentFeedbackView, view,), {})

--- a/thumber/views.py
+++ b/thumber/views.py
@@ -2,7 +2,6 @@ import os
 from urllib.parse import urlparse
 from itertools import chain
 
-from django.views.generic.edit import View
 from django.core.urlresolvers import resolve
 from django.conf import settings
 from django.http import JsonResponse
@@ -10,14 +9,6 @@ from django.http import HttpResponseNotAllowed
 
 from .models import ContentFeedback
 from .forms import ContentFeedbackForm
-
-
-__all__ = ['thumber_feedback']
-
-
-def thumber_feedback(view):
-    # Make a new class that inherits from the ContentFeedbackView, and the wrapped view class
-    return type('ThumberFeedbackView', (ContentFeedbackView, view,), {})
 
 
 class ContentFeedbackView():


### PR DESCRIPTION
Make the decorator raise an exception if not wrapping a django class-based view
Updated tests and README