### PR TITLE
Fix a bug where the thumber merely assumed the first template in a vi…

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -27,6 +27,17 @@ class ThumberTests(TestCase):
         self.assertIn('thumber_form', response.context)
         self.assertEquals(response.context['example_key'], 'example_val')
 
+    def test_multiple_templates(self):
+        # Use a view that specifies multiple templates, and ensure that the correct template is found and works
+        response = self.client.get(reverse('thumber_tests:multiexample'))
+        # Ensure it has it's regular content and the thumber form
+        self.assertContains(response, 'Example Template!', status_code=200)
+        self.assertContains(response, 'Was this service useful?')
+
+        # Check the context to make sure it has both the thumber_form, and what the view would normally add
+        self.assertIn('thumber_form', response.context)
+        self.assertEquals(response.context['example_key'], 'example_val')
+
     def test_original_post_method(self):
         # Use a form view and post it's normal form back to it to make sure the thumber post handling is ignored
         data = {'char_field': 'foo'}

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -8,6 +8,7 @@ app_name = 'thumber_tests'
 
 urlpatterns = [
     url(r'^example$', views.ExampleTemplateView.as_view(), name='example'),
+    url(r'^multiexample$', views.ExampleMultipleTemplateView.as_view(), name='multiexample'),
     url(r'^bad_example$', views.BadExampleTemplateView.as_view(), name='bad_example'),
     url(r'^kwargs_example/(?P<slug>[\w-]+)$', views.KwargsExampleView.as_view(), name='kwargs_example'),
     url(r'^form$', views.ExampleFormView.as_view(), name='example_form'),

--- a/tests/views.py
+++ b/tests/views.py
@@ -17,6 +17,16 @@ class ExampleTemplateView(TemplateView):
 
 
 @thumber_feedback
+class ExampleMultipleTemplateView(TemplateView):
+
+    def get_template_names(self):
+        return ['non_existant.html', 'example.html']
+
+    def get_context_data(self, **kwargs):
+        return {'example_key': 'example_val'}
+
+
+@thumber_feedback
 class KwargsExampleView(TemplateView):
     template_name = 'example.html'
 

--- a/thumber/templates/thumber/base.html
+++ b/thumber/templates/thumber/base.html
@@ -1,4 +1,4 @@
-{% extends template_name %}
+{% extends parent_template %}
 
 {% load staticfiles %}
 


### PR DESCRIPTION
…ew's get_template_name return value.

Now correctly find a valid template from whatever get_template_names may validly return.
Updated unit tests.